### PR TITLE
Add audit log downloader script

### DIFF
--- a/audit_api/README.md
+++ b/audit_api/README.md
@@ -136,7 +136,7 @@ jq '.[] | select(.eventType == "LogInEvent")' audit_logs.json
 - `CreateAccessTokenEvent` - Access token creation
 - `UpdateIngestionSourceEvent` - Ingestion source configuration change
 - `UpdateUserEvent` - User profile update
-- And many more...
+-  And more, see https://docs.datahub.com/docs/actions/events/audit-events-search-guide#createupdatedelete-event-types
 
 ## Requirements
 

--- a/audit_api/README.md
+++ b/audit_api/README.md
@@ -1,0 +1,148 @@
+# DataHub Audit Log Downloader
+
+This script downloads audit logs from DataHub using the [Audit Events Search API](https://docs.datahub.com/docs/actions/events/audit-events-search-guide).
+
+## Features
+
+- Download audit logs with flexible date ranges
+- Filter by event types, entity types, aspect types, and actors
+- Multiple output formats: JSON, JSONL, CSV
+- Paginated retrieval with configurable page size
+- Optional inclusion of raw event data
+
+## Installation
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Configuration
+
+The script uses the DataHub Python client's default configuration. Set up your connection using environment variables:
+
+```bash
+export DATAHUB_GMS_URL=https://your-instance.acryl.io/gms
+export DATAHUB_GMS_TOKEN=your-token-here
+```
+
+Or configure via `~/.datahubenv`:
+
+```
+DATAHUB_GMS_URL=https://your-instance.acryl.io/gms
+DATAHUB_GMS_TOKEN=your-token-here
+```
+
+## Usage
+
+### Basic Examples
+
+Download last 24 hours of logs (default):
+```bash
+python script.py
+```
+
+Download logs for specific date range:
+```bash
+python script.py --start-date "2025-01-01 00:00:00" --end-date "2025-01-02 00:00:00"
+```
+
+Download logs filtered by event type:
+```bash
+python script.py --event-types "LogInEvent,FailedLogInEvent"
+```
+
+Download logs for specific user:
+```bash
+python script.py --actor-urns "urn:li:corpuser:john.doe"
+```
+
+Export to CSV:
+```bash
+python script.py --format csv --output audit_logs.csv
+```
+
+Export to JSONL (one event per line):
+```bash
+python script.py --format jsonl --output audit_logs.jsonl
+```
+
+### Command Line Options
+
+- `--output`, `-o`: Output file path (default: audit_logs.json)
+- `--format`: Output format - json, jsonl, or csv (default: json)
+- `--start-date`: Start date in "YYYY-MM-DD HH:MM:SS" format (default: 24 hours ago)
+- `--end-date`: End date in "YYYY-MM-DD HH:MM:SS" format (default: now)
+- `--event-types`: Comma-separated list of event types to filter
+- `--entity-types`: Comma-separated list of entity types to filter
+- `--aspect-types`: Comma-separated list of aspect types to filter
+- `--actor-urns`: Comma-separated list of actor URNs to filter
+- `--page-size`: Number of events per page (default: 100)
+- `--include-raw/--no-include-raw`: Include raw event data (default: true)
+
+## Output Formats
+
+### JSON
+Standard JSON array format with pretty printing:
+```json
+[
+  {
+    "eventType": "LogInEvent",
+    "timestamp": 1765812228069,
+    "actorUrn": "urn:li:corpuser:admin",
+    ...
+  },
+  ...
+]
+```
+
+### JSONL
+One JSON object per line (newline-delimited JSON):
+```json
+{"eventType": "LogInEvent", "timestamp": 1765812228069, ...}
+{"eventType": "UpdateIngestionSourceEvent", "timestamp": 1765801335566, ...}
+```
+
+### CSV
+Flattened format with key fields:
+```csv
+eventType,timestamp,actorUrn,sourceIP,eventSource,userAgent
+LogInEvent,1765812228069,urn:li:corpuser:admin,,,
+```
+
+## Analyzing Logs
+
+The JSON output can be processed with `jq`:
+
+```bash
+# Extract all event types
+jq -r '.[].eventType' audit_logs.json | sort -u
+
+# Count events by type
+jq -r '.[].eventType' audit_logs.json | sort | uniq -c | sort -rn
+
+# Filter events by specific user
+jq '.[] | select(.actorUrn == "urn:li:corpuser:admin")' audit_logs.json
+
+# Extract login events
+jq '.[] | select(.eventType == "LogInEvent")' audit_logs.json
+```
+
+## Common Event Types
+
+- `LogInEvent` - User login
+- `FailedLogInEvent` - Failed login attempt
+- `CreateAccessTokenEvent` - Access token creation
+- `UpdateIngestionSourceEvent` - Ingestion source configuration change
+- `UpdateUserEvent` - User profile update
+- And many more...
+
+## Requirements
+
+- Python 3.7+
+- acryl-datahub
+- click
+- rich
+
+See [requirements.txt](../requirements.txt) for full dependency list.

--- a/audit_api/script.py
+++ b/audit_api/script.py
@@ -1,0 +1,337 @@
+# ABOUTME: CLI tool for downloading audit logs from DataHub using the audit events search API
+# ABOUTME: Supports filtering by event types, entity types, aspect types, and actors with configurable output formats
+
+import logging
+import json
+import csv
+from datetime import datetime, timedelta
+from typing import Optional, List
+import click
+from rich.logging import RichHandler
+from rich.console import Console
+
+from datahub.ingestion.graph.client import (
+    DataHubGraph,
+    get_default_graph
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(message)s",
+    datefmt="[%X]",
+    handlers=[RichHandler()]
+)
+
+logger = logging.getLogger("rich")
+console = Console()
+
+
+def get_timestamp_ms(date_str: str) -> int:
+    """Convert date string to timestamp in milliseconds."""
+    dt_obj = datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S")
+    return int(dt_obj.timestamp() * 1000)
+
+
+def download_audit_logs(
+    graph: DataHubGraph,
+    output_file: str,
+    start_time: Optional[int] = None,
+    end_time: Optional[int] = None,
+    event_types: Optional[List[str]] = None,
+    entity_types: Optional[List[str]] = None,
+    aspect_types: Optional[List[str]] = None,
+    actor_urns: Optional[List[str]] = None,
+    page_size: int = 100,
+    include_raw: bool = True,
+    output_format: str = "json"
+) -> int:
+    """
+    Download audit logs from DataHub.
+
+    Returns the total number of events downloaded.
+    """
+    gms_host = graph._gms_server
+    session = graph._session
+    url = f"{gms_host}/openapi/v1/events/audit/search"
+
+    # Build query parameters
+    params = {
+        "size": page_size,
+        "includeRaw": str(include_raw).lower()
+    }
+
+    if start_time:
+        params["startTime"] = start_time
+    if end_time:
+        params["endTime"] = end_time
+
+    # Build request body for filters
+    filters = {}
+    if event_types:
+        filters["eventTypes"] = event_types
+    if entity_types:
+        filters["entityTypes"] = entity_types
+    if aspect_types:
+        filters["aspectTypes"] = aspect_types
+    if actor_urns:
+        filters["actorUrns"] = actor_urns
+
+    headers = {
+        "Content-Type": "application/json",
+        "accept": "application/json",
+    }
+
+    total_downloaded = 0
+    scroll_id = None
+    first_page = True
+
+    # Initialize output file based on format
+    if output_format == "json":
+        with open(output_file, "w") as f:
+            f.write("[")
+    elif output_format == "jsonl":
+        with open(output_file, "w") as f:
+            pass
+    elif output_format == "csv":
+        pass
+
+    csv_writer = None
+    csv_file = None
+    csv_headers_written = False
+
+    try:
+        if output_format == "csv":
+            csv_file = open(output_file, "w", newline="")
+            csv_writer = csv.writer(csv_file)
+
+        while first_page or scroll_id:
+            first_page = False
+
+            if scroll_id:
+                params["scrollId"] = scroll_id
+
+            response = session.post(
+                url,
+                params=params,
+                json=filters if filters else {},
+                headers=headers
+            )
+            response.raise_for_status()
+
+            data = response.json()
+            events = data.get("usageEvents", [])
+            scroll_id = data.get("nextScrollId")
+
+            if not events:
+                break
+
+            # Write events based on format
+            if output_format == "json":
+                with open(output_file, "a") as f:
+                    for i, event in enumerate(events):
+                        if total_downloaded > 0 or i > 0:
+                            f.write(",\n")
+                        json.dump(event, f, indent=2)
+
+            elif output_format == "jsonl":
+                with open(output_file, "a") as f:
+                    for event in events:
+                        json.dump(event, f)
+                        f.write("\n")
+
+            elif output_format == "csv":
+                for event in events:
+                    flat_event = {
+                        "eventType": event.get("eventType"),
+                        "timestamp": event.get("timestamp"),
+                        "actorUrn": event.get("actorUrn"),
+                        "sourceIP": event.get("sourceIP"),
+                        "eventSource": event.get("eventSource"),
+                        "userAgent": event.get("userAgent"),
+                    }
+
+                    if csv_writer is not None:
+                        if not csv_headers_written:
+                            csv_writer.writerow(flat_event.keys())
+                            csv_headers_written = True
+
+                        csv_writer.writerow(flat_event.values())
+
+            total_downloaded += len(events)
+            logger.info(f"Downloaded {total_downloaded} events...")
+
+        if output_format == "json":
+            with open(output_file, "a") as f:
+                f.write("\n]")
+
+    finally:
+        if csv_file:
+            csv_file.close()
+
+    return total_downloaded
+
+
+@click.command()
+@click.option(
+    "--output",
+    "-o",
+    default="audit_logs.json",
+    help="Output file path",
+    show_default=True
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["json", "jsonl", "csv"], case_sensitive=False),
+    default="json",
+    help="Output format",
+    show_default=True
+)
+@click.option(
+    "--start-date",
+    help="Start date in YYYY-MM-DD HH:MM:SS format (default: 24 hours ago)"
+)
+@click.option(
+    "--end-date",
+    help="End date in YYYY-MM-DD HH:MM:SS format (default: now)"
+)
+@click.option(
+    "--event-types",
+    help="Comma-separated list of event types to filter"
+)
+@click.option(
+    "--entity-types",
+    help="Comma-separated list of entity types to filter"
+)
+@click.option(
+    "--aspect-types",
+    help="Comma-separated list of aspect types to filter"
+)
+@click.option(
+    "--actor-urns",
+    help="Comma-separated list of actor URNs to filter"
+)
+@click.option(
+    "--page-size",
+    default=100,
+    help="Number of events per page",
+    show_default=True
+)
+@click.option(
+    "--include-raw/--no-include-raw",
+    default=True,
+    help="Include raw event data",
+    show_default=True
+)
+def main(
+    output: str,
+    output_format: str,
+    start_date: Optional[str],
+    end_date: Optional[str],
+    event_types: Optional[str],
+    entity_types: Optional[str],
+    aspect_types: Optional[str],
+    actor_urns: Optional[str],
+    page_size: int,
+    include_raw: bool
+):
+    """
+    Download audit logs from DataHub.
+
+    Examples:
+
+    \b
+    # Download last 24 hours of logs
+    python script.py
+
+    \b
+    # Download logs for specific date range
+    python script.py --start-date "2025-01-01 00:00:00" --end-date "2025-01-02 00:00:00"
+
+    \b
+    # Download logs filtered by event type
+    python script.py --event-types "LogInEvent,FailedLogInEvent"
+
+    \b
+    # Download logs for specific user
+    python script.py --actor-urns "urn:li:corpuser:john.doe"
+
+    \b
+    # Export to CSV
+    python script.py --format csv --output audit_logs.csv
+    """
+    console.print("[bold blue]DataHub Audit Log Downloader[/bold blue]")
+
+    start_time = None
+    end_time = None
+
+    if start_date:
+        try:
+            start_time = get_timestamp_ms(start_date)
+        except ValueError:
+            console.print("[bold red]Error:[/bold red] Invalid start date format. Use YYYY-MM-DD HH:MM:SS")
+            return
+    else:
+        start_time = int((datetime.now() - timedelta(days=1)).timestamp() * 1000)
+
+    if end_date:
+        try:
+            end_time = get_timestamp_ms(end_date)
+        except ValueError:
+            console.print("[bold red]Error:[/bold red] Invalid end date format. Use YYYY-MM-DD HH:MM:SS")
+            return
+    else:
+        end_time = int(datetime.now().timestamp() * 1000)
+
+    event_types_list = event_types.split(",") if event_types else None
+    entity_types_list = entity_types.split(",") if entity_types else None
+    aspect_types_list = aspect_types.split(",") if aspect_types else None
+    actor_urns_list = actor_urns.split(",") if actor_urns else None
+
+    console.print(f"\n[cyan]Configuration:[/cyan]")
+    console.print(f"  Output file: {output}")
+    console.print(f"  Output format: {output_format}")
+    console.print(f"  Start time: {datetime.fromtimestamp(start_time / 1000)}")
+    console.print(f"  End time: {datetime.fromtimestamp(end_time / 1000)}")
+    if event_types_list:
+        console.print(f"  Event types: {', '.join(event_types_list)}")
+    if entity_types_list:
+        console.print(f"  Entity types: {', '.join(entity_types_list)}")
+    if aspect_types_list:
+        console.print(f"  Aspect types: {', '.join(aspect_types_list)}")
+    if actor_urns_list:
+        console.print(f"  Actor URNs: {', '.join(actor_urns_list)}")
+    console.print()
+
+    try:
+        graph = get_default_graph()
+        console.print(f"[green]Connected to DataHub:[/green] {graph._gms_server}")
+    except Exception as e:
+        console.print(f"[bold red]Error connecting to DataHub:[/bold red] {e}")
+        return
+
+    try:
+        total = download_audit_logs(
+            graph=graph,
+            output_file=output,
+            start_time=start_time,
+            end_time=end_time,
+            event_types=event_types_list,
+            entity_types=entity_types_list,
+            aspect_types=aspect_types_list,
+            actor_urns=actor_urns_list,
+            page_size=page_size,
+            include_raw=include_raw,
+            output_format=output_format
+        )
+
+        console.print(f"\n[bold green]Success![/bold green] Downloaded {total} events to {output}")
+
+    except Exception as e:
+        console.print(f"\n[bold red]Error downloading logs:[/bold red] {e}")
+        logger.exception("Full error details:")
+        return
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-acryl-datahub==1.3.0
+acryl-datahub==1.2.0.9
 acryl-datahub-cloud==0.3.14.1
 rich==14.0.0
 ruff==0.11.5
+click==8.1.7


### PR DESCRIPTION
## Summary
- Add CLI tool for downloading audit logs from DataHub using the Audit Events Search API
- Support filtering by event types, entity types, aspect types, and actors
- Multiple output formats: JSON, JSONL, CSV
- Fix JSON array formatting bug to ensure valid JSON output
- Add comprehensive README with installation, configuration, usage examples, and jq analysis commands

## Features
- Flexible date range filtering (defaults to last 24 hours)
- Configurable page size for pagination
- Optional raw event data inclusion
- Rich console output with progress tracking
- Proper error handling and validation

## Test plan
- [x] Script generates valid JSON output (verified with jq)
- [x] Pagination works correctly across multiple pages
- [x] Date filtering works as expected
- [x] Documentation includes clear examples and setup instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)